### PR TITLE
docs: Add JavaDoc to memoize method in SuppliersGenerator

### DIFF
--- a/generators/java/sdk/src/main/java/com/fern/java/client/generators/SuppliersGenerator.java
+++ b/generators/java/sdk/src/main/java/com/fern/java/client/generators/SuppliersGenerator.java
@@ -61,6 +61,9 @@ public final class SuppliersGenerator extends AbstractFileGenerator {
         TypeName genericSupplier = ParameterizedTypeName.get(ClassName.get(Supplier.class), genericType);
         TypeName genericAtomicReference = ParameterizedTypeName.get(ClassName.get(AtomicReference.class), genericType);
         return MethodSpec.methodBuilder(MEMOIZE_METHOD_NAME)
+                .addJavadoc("Returns a supplier which caches the result of the delegate supplier.\n")
+                .addJavadoc("@param delegate the supplier whose result should be cached\n")
+                .addJavadoc("@return a memoizing supplier\n")
                 .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
                 .addTypeVariable(genericType)
                 .returns(genericSupplier)


### PR DESCRIPTION
Adds JavaDoc documentation to the memoize method. This is a safe change that should pass all tests.